### PR TITLE
Uses webpack for styles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ export PATH := ./node_modules/.bin:${PATH}
 # Compile the API from the lib directory into dist/cf-widget-api.js
 build:
 	webpack
-	@echo "Created 'dist/cf-widget-api-js'"
-	@mkdir -p dist
-	./node_modules/stylus/bin/stylus -u nib lib/style/index.styl -o dist/cf-widget-api.css --sourcemap
 
 docs: build
 	@mkdir -p dist

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
     "stylus": "^0.52.4",
     "webpack": "^1.12.2",
     "yaku": "^0.11.4"
+  },
+  "devDependencies": {
+    "css-loader": "^0.23.0",
+    "extract-text-webpack-plugin": "^0.9.1",
+    "style-loader": "^0.13.0",
+    "stylus-loader": "^1.4.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,24 +1,40 @@
-var path = require('path')
+var path = require('path');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+// https://github.com/webpack/css-loader/issues/145
+require('es6-promise').polyfill();
 
 module.exports = {
   entry: {
-    'cf-widget-api': './lib/api/index.js'
+    'cf-widget-api.js': './lib/api/index.js',
+    'cf-widget-api.css': './lib/style/index.styl'
   },
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: '[name].js'
+    filename: '[name]'
+  },
+  resolve: {
+    extensions: ['', '.js', '.css', '.styl']
   },
   module: {
     loaders: [
       {
-        test: /\.jsx?$/,
+        test: /\.js$/,
         exclude: /(node_modules|bower_components)/,
         loader: 'babel',
         query: {
           presets: ['es2015']
         }
+      }, {
+        test: /\.styl$/,
+        loader: ExtractTextPlugin.extract(
+          'css?sourceMap!stylus?sourceMap'
+        )
       }
     ]
   },
-  devtool: 'source-map'
+  plugins: [
+    new ExtractTextPlugin('cf-widget-api.css', {allChunks: true})
+  ],
+  devtool: 'source-map',
 }


### PR DESCRIPTION
Instead of calling stylus in the Makefile, webpack can take care of this.
This has the aim to create source maps for .styl files which still work in
example projects after copying the `cf-widget-api.css` and its `.map` to
the example's `dist` folder.

TODO: Generated `cf-widget-api.css.map` seems messed up for some
      reason. Figure out why and fix it.