### PR TITLE
Fixes widget.json `src` for example widgets

### DIFF
--- a/examples/alloy-editor/widget.json
+++ b/examples/alloy-editor/widget.json
@@ -1,6 +1,6 @@
 {
   "id": "alloy",
   "name": "Rich Text Editor",
-  "src": "http://localhost:3000",
+  "src": "http://localhost:3000/",
   "fieldTypes": ["Text"]
 }

--- a/examples/chessboard/widget.json
+++ b/examples/chessboard/widget.json
@@ -1,6 +1,6 @@
 {
   "id": "chessboard",
   "name": "Chessboard",
-  "src": "http://localhost:3000",
+  "src": "http://localhost:3000/",
   "fieldTypes": ["Object"]
 }

--- a/examples/json-editor/widget.json
+++ b/examples/json-editor/widget.json
@@ -1,6 +1,6 @@
 {
   "id": "jsonEditor",
   "name": "JSON Editor",
-  "src": "http://localhost:3000",
+  "src": "http://localhost:3000/",
   "fieldTypes": ["Object"]
 }

--- a/examples/json-form-editor/README.md
+++ b/examples/json-form-editor/README.md
@@ -22,7 +22,7 @@ export CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=<contentfulManagementApiToken>
 contentful-widget create --space-id <yourSpaceId>
 ```
 
-Serve on `http://localhost:3000`:
+Serve on `http://localhost:3000/`:
 ```bash
 gulp watch
 ```

--- a/examples/json-form-editor/src/json-form-editor.js
+++ b/examples/json-form-editor/src/json-form-editor.js
@@ -5,6 +5,10 @@
 
 'use strict';
 
+var cfWidget = window.contentfulWidget;
+
+cfWidget.init(initContentfulJsonFormEditor);
+
 function initContentfulJsonFormEditor (cfApi) {
   cfApi.window.startAutoResizer();
 
@@ -34,9 +38,7 @@ function initContentfulJsonFormEditor (cfApi) {
       cfApi.field.setValue(currentJSON);
     }
   }, 150);
-};
-
-window.contentfulWidget.init(initContentfulJsonFormEditor);
+}
 
 function createElement (elem, opts, parent) {
   var e = document.createElement(elem);
@@ -48,7 +50,7 @@ function createElement (elem, opts, parent) {
   parent = parent || document.body;
   parent.appendChild(e);
   return e;
-};
+}
 
 // http://davidwalsh.name/javascript-debounce-function
 function debounce (func, wait) {

--- a/examples/json-form-editor/widget.json
+++ b/examples/json-form-editor/widget.json
@@ -1,6 +1,6 @@
 {
   "id": "jsonFormEditor",
   "name": "JSON Form Editor",
-  "src": "http://localhost:3000",
+  "src": "http://localhost:3000/",
   "fieldTypes": ["Object"]
 }

--- a/examples/rating-dropdown/README.md
+++ b/examples/rating-dropdown/README.md
@@ -82,7 +82,7 @@ python -m SimpleHTTPServer 8000
 ~~~
 
 This will update the widget and tell the Contentful App to load the widget from
-`http://localhost:3000/app.html` instead of loading it from the API. It will
+`http://localhost:8000/app.html` instead of loading it from the API. It will
 also run a static server to serve that file. (If you don’t have Python installed
 there are [various ways to serve static files][static-one-liners].)
 

--- a/examples/translate/widget.json
+++ b/examples/translate/widget.json
@@ -1,6 +1,6 @@
 {
   "id": "translate",
   "name": "Translate Widget",
-  "src": "http://localhost:3000",
+  "src": "http://localhost:3000/",
   "fieldTypes": ["Symbol", "Text"]
 }


### PR DESCRIPTION
The `contentful-widget` cli would reject localhost urls without "/" concluding the domain. With this change the examples should work out of the box again.