### PR TITLE
Slug widget: Fix broken slug editor

### DIFF
--- a/examples/slug/Makefile
+++ b/examples/slug/Makefile
@@ -1,21 +1,19 @@
-# Put your token and space id here.
-TOKEN=f00b4r
-SPACE=my5p4c3
+# Uncomment the lines below after adding your data
+# export CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=<your token>
+# export SPACE=<id of space you want to install the widget for>
 
-export PATH := ../../bin:${PATH}
-export CONTENTFUL_MANAGEMENT_ACCESS_TOKEN := $(TOKEN)
+BIN=./node_modules/.bin
 
 build: index.built.html
 
 # Inject all javascript files into 'index.html' to produce 'index.built.html'
-index.built.html: index.html app.js
+index.built.html: app.js index.html
 	cp index.html $@
 	echo "<script>" >> $@
-	uglifyjs cf-widget-api.js>> $@
+	$(BIN)/browserify -d -t [ babelify --presets [ es2015 ] ] --entry $<  >> $@
 	echo "</script>" >> $@
-	echo "<script>" >> $@
-	uglifyjs app.js>> $@
-	echo "</script>" >> $@
+
+.PHONY: build index.built.html
 
 create: widget.json index.built.html
 	contentful-widget create --space-id ${SPACE}

--- a/examples/slug/app.js
+++ b/examples/slug/app.js
@@ -1,10 +1,16 @@
-var input = document.getElementById('slug')
+import { init } from '../../lib/api'
 
-// The IDs of the content types we check for duplicate slug values.
-var contentTypes = ['slug', 'slug2']
 
-window.contentfulWidget.init(function (api) {
-  var statusElements = {
+init(api => {
+  const slugField = api.field
+  const titleField = api.entry.fields.title
+
+  const _ = window._
+  const getSlug = window.getSlug
+  const debouncedUpdateStatus = _.debounce(updateStatus, 500)
+
+  const input = document.getElementById('slug')
+  const statusElements = {
     error: document.getElementById('error'),
     ok: document.getElementById('ok'),
     loading: document.getElementById('loading')
@@ -12,16 +18,20 @@ window.contentfulWidget.init(function (api) {
 
   api.window.updateHeight()
 
-  var slugField = api.field
-  var titleField = api.entry.fields.title
+  titleField.onValueChanged(handleSlugChange)
 
-  titleField.onValueChanged(function (title) {
-    setSlug(window.getSlug(title || ''))
-  })
-
-  var debouncedUpdateStatus = _.debounce(updateStatus, 500)
+  input.addEventListener('input', () => handleSlugChange(input.value))
+  input.addEventListener('change', () => handleSlugChange(input.value))
 
   updateStatus(slugField.getValue())
+
+  /**
+   * Handle change of slug value caused by either changing slug field
+   * or changing the title of the entry
+   */
+  function handleSlugChange (value) {
+    setSlug(getSlug(value || ''))
+  }
 
   /**
    * Set the input value to 'slug' and update the status by checking for
@@ -30,21 +40,27 @@ window.contentfulWidget.init(function (api) {
   function setSlug (slug) {
     input.value = slug
     slugField.setValue(slug)
-    setStatusStyle('loading')
+    setStatus('loading')
     debouncedUpdateStatus(slug)
   }
 
-  function updateStatus(slug) {
+  /**
+   * Show inline status icon based on current status
+   */
+  function updateStatus (slug) {
     getDuplicates(slug).then(function (hasDuplicates) {
       if (hasDuplicates) {
-        setStatusStyles('error')
+        setStatus('error')
       } else {
-        setStatusStyles('ok')
+        setStatus('ok')
       }
     })
   }
 
-  function setStatusStyles (status) {
+  /**
+   * Show icon for given status
+   */
+  function setStatus (status) {
     _.each(statusElements, function (el, name) {
       if (name === status) {
         el.style.display = 'inline'
@@ -55,34 +71,23 @@ window.contentfulWidget.init(function (api) {
   }
 
 
-  function hasDuplicates (slug) {
+  /**
+   * Check if slug is already in use.
+   * Resolves to 'true' if there are entries of the given content type that have
+   * the same 'slug' value.
+   */
+  function getDuplicates (slug) {
     if (!slug) {
       return Promise.resolve(false)
     }
 
-    return Promise.all(
-      contentTypes.map(function (ct) {
-        return contentTypeDuplicates(ct, slug)
-      })
-    ).then(function (values) {
-      return _.any(values)
-    })
-  }
+    let query = {}
 
-  /**
-   * Resolves to 'true' if there are entries of the given content type that have
-   * the same 'slug' value.
-   */
-  function contentTypeDuplicates (ct, slug) {
-    var query = {}
-    query['content_type'] = ct
-    query['fields.' + api.field.id] = slug;
-    query['sys.id[ne]'] = api.entry.getSys().id;
-    query['sys.publishedAt[exists]'] = true;
+    query['content_type'] = api.entry.getSys().contentType.sys.id
+    query['fields.' + slugField.id] = slug
+    query['sys.id[ne]'] = api.entry.getSys().id
+    query['sys.publishedAt[exists]'] = true
 
-    return api.space.getEntries(query)
-    .then(function (result) {
-      return result.length > 0
-    })
+    return api.space.getEntries(query).then(result => result.total > 0)
   }
 })

--- a/examples/slug/index.html
+++ b/examples/slug/index.html
@@ -2,9 +2,6 @@
 <head>
   <link href="https://static.contentful.com/app/main-62e0abc7.css" media="all" rel="stylesheet" type="text/css">
   <link href="https://static.contentful.com/app/vendor-976872d7.css" media="all" rel="stylesheet" type="text/css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/3.0.2/es6-promise.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.1/lodash.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/speakingurl/7.0.0/speakingurl.min.js"></script>
 </head>
 <div class="widget-slug-editor">
   <input id="slug" type="text" class="form-control" style="width: 98%; font-size: 14px">
@@ -12,3 +9,6 @@
   <i id="ok" class="fa fa-check-circle is-slug-unique"></i>
   <i id="loading" class="fa fa-spinner fa-spin"></i>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/3.0.2/es6-promise.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.1/lodash.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/speakingurl/7.0.0/speakingurl.min.js"></script>

--- a/examples/slug/package.json
+++ b/examples/slug/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "slug",
+  "version": "1.0.0",
+  "description": "Widget to store unique slugs",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Thomas Scholtes <thomas@contentful.com>",
+  "contributors": [
+    "Mudit Ameta <mudit@contentful.com>"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "babel-preset-es2015": "^6.9.0",
+    "babelify": "^7.3.0",
+    "browserify": "^13.0.1"
+  },
+  "dependencies": {}
+}


### PR DESCRIPTION
Fix:

- Wrong method names
- Race conditions due to api not being loaded before the widget entry point was called
- How duplicates were looked up (this wasn't working at all)

Refactor:

- Rewrite using ES2015 to keep it consistent with other widgets
- Abstract away change handling into a function
- Rename functions based on what they do
- Added comments