### PR TITLE
Converge internal and public ui-extensions api

### DIFF
--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -1,20 +1,22 @@
 import Promise from 'yaku'
-import Signal from './signal'
+import { Signal } from './signal'
 
 export default class Channel {
 
   constructor (sourceId, targetWindow) {
     this.sourceId = sourceId
-    this.targetWindow = targetWindow
+    this.targetWindow = targetWindow // contentful webapp window
     this._messageCount = 0
     this._messageHandlers = {}
     this._responseHandlers = {}
 
+    // window refers to iframe contentWindow
     window.addEventListener('message', (event) => {
       this._handleMessage(event.data)
     })
   }
 
+  // call method with name `method` exposed by contentful web app `window`
   call (method, ...params) {
     const messageId = this._send(method, params)
     return new Promise((resolve, reject) => {

--- a/lib/api/entry.js
+++ b/lib/api/entry.js
@@ -1,10 +1,10 @@
-import Signal from './signal'
+import { MemoizedSignal } from './signal'
 import Field from './field'
 
 export default
 function createEntry (channel, entryData, fieldInfo, defaultLocale) {
   let sys = entryData.sys
-  let sysChanged = new Signal()
+  let sysChanged = new MemoizedSignal(sys)
 
   channel.addHandler('sysChanged', (_sys) => {
     sys = _sys

--- a/lib/api/field-locale.js
+++ b/lib/api/field-locale.js
@@ -1,19 +1,27 @@
-import Signal from './signal'
+import { MemoizedSignal } from './signal'
 
 export default class FieldLocale {
 
-  constructor (channel, {id, locale, value}) {
+  constructor (channel, {id, locale, value, type, isDisabled}) {
     this.id = id
     this.locale = locale
+    this.type = type
     this._value = value
-    this._valueSignal = new Signal()
+    this._valueSignal = new MemoizedSignal(value)
+    this._isDisabledSignal = new MemoizedSignal(isDisabled)
     this._channel = channel
 
     channel.addHandler('valueChanged', (id, locale, value) => {
-      if (id === this.id && (!locale || locale === this.locale)) {
+      if (id === this.id &&
+          (!locale || locale === this.locale) &&
+          this._value !== value) {
         this._value = value
         this._valueSignal.dispatch(value)
       }
+    })
+
+    channel.addHandler('isDisabledChanged', isDisabled => {
+      this._isDisabledSignal.dispatch(isDisabled)
     })
   }
 
@@ -26,8 +34,25 @@ export default class FieldLocale {
     return this._channel.call('setValue', this.id, this.locale, value)
   }
 
+  removeValue () {
+    this._value = undefined
+    return this._channel.call('removeValue', this.id, this.locale)
+  }
+
+  setInvalid (isInvalid) {
+    return this._channel.call('setInvalid', isInvalid, this.locale)
+  }
+
+  setActive (isActive) {
+    return this._channel.call('setActive', isActive)
+  }
+
   onValueChanged (handler) {
     return this._valueSignal.attach(handler)
+  }
+
+  onIsDisabledChanged (handler) {
+    return this._isDisabledSignal.attach(handler)
   }
 
 }

--- a/lib/api/field.js
+++ b/lib/api/field.js
@@ -37,6 +37,15 @@ export default class Field {
     return this._getFieldLocale(locale).onValueChanged(handler)
   }
 
+  onIsDisabledChanged (locale, handler) {
+    if (!handler) {
+      handler = locale
+      locale = undefined
+    }
+
+    return this._getFieldLocale(locale).onIsDisabledChanged(handler)
+  }
+
   _getFieldLocale (locale) {
     locale = locale || this._defaultLocale
     assertHasLocale(this, locale)

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -6,12 +6,13 @@ import createSpace from './space'
 
 export var init = initializeApi(createWidgetAPI)
 
-function createWidgetAPI (channel, {entry, locales, field, fieldInfo}) {
+function createWidgetAPI (channel, {entry, locales, field, fieldInfo, contentType}) {
   return {
     locales,
     field: new FieldLocale(channel, field),
     entry: createEntry(channel, entry, fieldInfo, locales.default),
     space: createSpace(channel),
-    window: createWindow(channel)
+    window: createWindow(channel),
+    contentType: contentType
   }
 }

--- a/lib/api/initialize.js
+++ b/lib/api/initialize.js
@@ -1,12 +1,12 @@
 import Channel from './channel'
-import Signal from './signal'
+import { Signal } from './signal'
 
 export default function initializeApi (apiCreator) {
   const channel = new Channel(null, window.parent)
   let apiInitCallbacks = new Signal()
   let createdApi
 
-  const removeHandler = channel.addHandler('connect', function (params) {
+  const removeHandler = channel.addHandler('connect', (params) => {
     removeHandler()
     channel.sourceId = params.id
 

--- a/lib/api/signal.js
+++ b/lib/api/signal.js
@@ -1,4 +1,6 @@
-export default class Signal {
+require('core-js/es6/symbol')
+
+export class Signal {
   constructor () {
     this._id = 0
     this._listeners = {}
@@ -14,11 +16,38 @@ export default class Signal {
     if (typeof listener !== 'function') {
       throw new Error('listener function expected')
     }
-    var id = this._id++
+    const id = this._id++
     this._listeners[id] = listener
-    var self = this
-    return function removeListener () {
-      delete self._listeners[id]
+    // return function that'll detach the listener
+    return () => delete this._listeners[id]
+  }
+}
+
+const memArgsSymbol = Symbol('Private memoized arguments')
+
+export class MemoizedSignal extends Signal {
+  constructor (...memoizedArgs) {
+    if (!memoizedArgs.length) {
+      throw new Error('Initial value to be memoized expected')
     }
+    super()
+    this[memArgsSymbol] = memoizedArgs
+  }
+
+  dispatch (...args) {
+    this[memArgsSymbol] = args
+    super.dispatch(...args)
+  }
+
+  attach (listener) {
+    /*
+     * attaching first so that we throw a sensible
+     * error if listener is not a function without
+     * duplication of is function check
+     */
+    const detachListener = super.attach(listener)
+
+    listener(...this[memArgsSymbol])
+    return detachListener
   }
 }

--- a/lib/api/space.js
+++ b/lib/api/space.js
@@ -3,6 +3,8 @@ const spaceMethods = [
   'getEntry',
   'getAsset',
 
+  'getPublishedEntries',
+  'getPublishedAssets',
   'getContentTypes',
   'getEntries',
   'getAssets',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "babel-loader": "^6.0.1",
     "babel-preset-es2015": "^6.0.15",
+    "core-js": "^2.4.0",
     "es6-promise": "^3.0.2",
     "kss": "^2.3.1",
     "nib": "^1.1.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,7 @@
 {
   "rules": {
-    "no-new": 0
+    "no-new": 0,
+    "no-unused-vars": [2, {vars: 'all', args: 'all', argsIgnorePattern: '^_', varsIgnorePattern: '^_'}]
   },
   "env": {
     "browser": true,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,8 +5,8 @@ export function describeAttachHandlerMember (msg, attachHandlerFn) {
     it('returns a function to detach the handler', () => {
       expect(attachHandlerFn()).to.be.a('function')
     })
-    describe(`returned function`, () => {
-      it(`can be executed without error`, () => {
+    describe('returned function', () => {
+      it('can be executed without error', () => {
         let detachHandler = attachHandlerFn()
         expect(detachHandler).to.not.throw()
       })

--- a/test/unit/entry.spec.js
+++ b/test/unit/entry.spec.js
@@ -4,8 +4,8 @@ import {
   describeAttachHandlerMember
 } from '../helpers'
 
-describe(`createEntry()`, () => {
-  describe(`returned "entry" object`, () => {
+describe('createEntry()', () => {
+  describe('returned "entry" object', () => {
     const entryData = {sys: {}}
     const fieldInfo = [
       {
@@ -38,40 +38,50 @@ describe(`createEntry()`, () => {
       entry = createEntry(channelStub, entryData, fieldInfo, defaultLocale)
     })
 
-    it(`subscribed to injected Channel's "sysChanged"`, () => {
+    it('subscribed to injected Channel\'s "sysChanged"', () => {
       const spy = channelStub.addHandler
       expect(spy).to.have.been.calledWithExactly('sysChanged', sinon.match.func)
     })
 
-    describe(`.fields[id]`, () => {
-      it(`exists for each constructor given field info`, () => {
+    describe('.fields[id]', () => {
+      it('exists for each constructor given field info', () => {
         const fieldIds = fieldInfo.map((info) => info.id)
         expect(Object.getOwnPropertyNames(entry.fields)).to.deep.equal(fieldIds)
       })
-      it(`got instantiated with its related constructor given field info`, () => {
+      it('got instantiated with its related constructor given field info', () => {
         Object.getOwnPropertyNames(entry.fields).forEach((fieldId) => {
           const info = fieldInfo.find((info) => info.id === fieldId)
           const field = entry.fields[fieldId]
           const fieldInstantiationCall =
-            FieldSpy.withArgs(channelStub, info, defaultLocale).firstCall
+                FieldSpy.withArgs(channelStub, info, defaultLocale).firstCall
 
           expect(fieldInstantiationCall).to.have.been.calledOn(field)
         })
       })
     })
 
-    describe(`.getSys()`, () => {
-      it(`returns entryData.sys given to constructor`, () => {
+    describe('.getSys()', () => {
+      it('returns entryData.sys given to constructor', () => {
         expect(entry.getSys()).to.equal(entryData.sys)
       })
     })
 
-    describeAttachHandlerMember(`.onSysChanged(handler)`, () => {
-      return entry.onSysChanged(noop)
+    describe('.onSysChanged(handler)', () => {
+      describeAttachHandlerMember('default behaviour', () => {
+        return entry.onSysChanged(noop)
+      })
+
+      it('calls handler immediately on attach with initial value of sys', () => {
+        const spy = sinon.spy()
+
+        entry.onSysChanged(spy)
+        sinon.assert.calledOnce(spy)
+        sinon.assert.calledWithExactly(spy, entryData.sys)
+      })
     })
 
-    describe(`injected channel propagating "sysChanged"`, () => {
-      it(`replaces current sys with the given one`, () => {
+    describe('injected channel propagating "sysChanged"', () => {
+      it('replaces current sys with the given one', () => {
         const newSys = {}
         // The handler registered with channel.addHandler("sysChanged", handler)
         const sysChangedHandler = channelStub.addHandler.args[0][1]

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -18,7 +18,9 @@ describe('FieldLocale', () => {
     const info = {
       id: 'some-field',
       locale: 'en-US',
-      value: 'Hello'
+      value: 'Hello',
+      type: 'Symbol',
+      isDisabled: true
     }
     let field
     beforeEach(() => {
@@ -26,79 +28,122 @@ describe('FieldLocale', () => {
       field = new FieldLocale(channelStub, infoCopy)
     })
 
-    it(`is a FieldLocale instance`, () => {
+    it('is a FieldLocale instance', () => {
       expect(field).to.be.instanceof(FieldLocale)
     })
 
     describe('.id', () => {
-      it(`is equal to info.id`, () => {
+      it('is equal to info.id', () => {
         expect(field.id).to.equal(info.id)
       })
     })
 
+    describe('.type', () => {
+      it('is equal to info.type', () => {
+        expect(field.type).to.equal(info.type)
+      })
+    })
+
+
     describe('.locale', () => {
-      it(`is set to the same value as given to first constructor arg's .locale`, () => {
+      it('is set to the same value as given to first constructor arg\'s .locale', () => {
         expect(field.locale).to.equal(info.locale)
       })
     })
 
     describe('.getValue()', () => {
-      it(`returns the field's value`, () => {
+      it('returns the field\'s value', () => {
         expect(field.getValue()).to.equal(info.value)
       })
     })
 
     describe('.setValue(value)', () => {
-      const newValue = `new-value`
+      testValueMethods('setValue', 'new-value')
+    })
+
+    describe('.removeValue()', () => {
+      testValueMethods('removeValue')
+    })
+
+    describe('.setInvalid()', () => {
+      it('invokes channel.call("${setInvalid}", ...)', () => {
+        field.setInvalid(true)
+        sinon.assert.calledWithExactly(channelStub.call, 'setInvalid', true, info.locale)
+      })
+    })
+
+    describe('.setActive()', () => {
+      it('invokes channel.call("${setActive}", ...)', () => {
+        field.setActive(true)
+        sinon.assert.calledWithExactly(channelStub.call, 'setActive', true)
+      })
+    })
+
+    describe('.onValueChanged(handler)', () => {
+      testChangeMethod('onValueChanged', info.value)
+    })
+
+    describe('.onIsDisabledChanged(handler)', () => {
+      testChangeMethod('onIsDisabledChanged', info.isDisabled)
+    })
+
+    describe('injected channel propagating "isDisabledChanged"', () => {
+      let isDisabledChangedHandler
 
       beforeEach(() => {
-        field.setValue(newValue)
+        isDisabledChangedHandler = channelStub.addHandler.args[1][1]
       })
 
-      it(`changes the value`, () => {
-        expect(field.getValue()).to.equal(newValue)
-      })
-      it(`invokes channel.call("setValue", ...)`, () => {
-        expect(channelStub.call).to.have.been.calledWithExactly(
-          'setValue', field.id, info.locale, newValue)
-      })
-      it(`returns the promise returned by internal channel.call()`, () => {
-        channelStub.call.withArgs('setValue').returns('PROMISE')
-        expect(field.setValue('val')).to.equal('PROMISE')
+      it('calls the handler with given value', () => {
+        const cb = sinon.spy()
+
+        field.onIsDisabledChanged(cb)
+        sinon.assert.calledOnce(cb)
+        sinon.assert.calledWithExactly(cb, info.isDisabled)
+        isDisabledChangedHandler('ISDISABLED')
+        sinon.assert.calledTwice(cb)
+        sinon.assert.calledWithExactly(cb, 'ISDISABLED')
       })
     })
 
-    describeAttachHandlerMember(`.onValueChanged(handler)`, () => {
-      return field.onValueChanged(noop)
-    })
-
-    describe(`injected channel propagating "valueChanged"`, () => {
+    describe('injected channel propagating "valueChanged"', () => {
       const newValue = 'some new, unused value'
-
       let valueChangedHandler
       beforeEach(() => {
         // The handler registered with channel.addHandler("valueChanged", handler)
         valueChangedHandler = channelStub.addHandler.args[0][1]
       })
 
-      describe(`targeted at another field's id`, () => {
-        it(`does not update the value`, () => {
+      describe('New value equals current value', () => {
+        it('does not dispatch new value', () => {
+          const oldValue = field.getValue()
+          const cb = sinon.spy()
+
+          field.onValueChanged(cb)
+          sinon.assert.calledOnce(cb)
+          valueChangedHandler(field.id, defaultLocale, oldValue)
+          sinon.assert.calledOnce(cb)
+        })
+      })
+
+      describe('targeted at another field\'s id', () => {
+        it('does not update the value', () => {
           const oldValue = field.getValue()
           valueChangedHandler(`${field.id}-other-id`, defaultLocale, newValue)
 
           expect(oldValue).to.equal(field.getValue())
         })
       })
-      describe(`targeted at the field's id`, () => {
-        describe(`for specific locale`, () => {
-          it(`sets the locale's value to the given one`, () => {
+      describe('targeted at the field\'s id', () => {
+        describe('for specific locale', () => {
+          it('sets the locale\'s value to the given one', () => {
             valueChangedHandler(field.id, defaultLocale, newValue)
 
             expect(field.getValue()).to.equal(newValue)
           })
         })
-        describe(`without locale provided`, () => {
-          it(`sets the locale's value to the given one`, () => {
+        describe('without locale provided', () => {
+          it('sets the locale\'s value to the given one', () => {
             valueChangedHandler(field.id, undefined, newValue)
 
             expect(field.getValue()).to.equal(newValue)
@@ -106,5 +151,44 @@ describe('FieldLocale', () => {
         })
       })
     })
+
+    function testValueMethods (method, newValue) {
+      beforeEach(() => {
+        field[method](newValue)
+      })
+
+      it(`sets the value to ${newValue}`, () => {
+        expect(field.getValue()).to.equal(newValue)
+      })
+
+      it('invokes channel.call("${method}", ...)', () => {
+        if (newValue === undefined) {
+          expect(channelStub.call).to.have.been.calledWithExactly(
+          method, field.id, info.locale)
+        } else {
+          expect(channelStub.call).to.have.been.calledWithExactly(
+          method, field.id, info.locale, newValue)
+        }
+      })
+
+      it('returns the promise returned by internal channel.call()', () => {
+        channelStub.call.withArgs(method).returns('PROMISE')
+        expect(field[method]('val')).to.equal('PROMISE')
+      })
+    }
+
+    function testChangeMethod (methodName, initialValue) {
+      describeAttachHandlerMember('default behaviour', () => {
+        return field[methodName](noop)
+      })
+
+      it('calls handler immediately on attach with initial value of field', () => {
+        const spy = sinon.spy()
+
+        field[methodName](spy)
+        sinon.assert.calledOnce(spy)
+        sinon.assert.calledWithExactly(spy, initialValue)
+      })
+    }
   })
 })

--- a/test/unit/signal.spec.js
+++ b/test/unit/signal.spec.js
@@ -1,107 +1,141 @@
-import Signal from '../../lib/api/signal'
+import { MemoizedSignal, Signal } from '../../lib/api/signal'
 import {noop} from '../helpers'
 
-describe(`Signal`, () => {
-  describe(`constructor`, () => {
-    it(`creates a Signal instance`, () => {
-      expect(new Signal()).to.be.instanceof(Signal)
-    })
+describe('MemoizedSignal', () => {
+  it('calls the listener with the initial value', () => {
+    const spy = sinon.spy()
+
+    new MemoizedSignal('zweiundvierzig').attach(spy)
+    expect(spy).to.have.been.calledWithExactly('zweiundvierzig')
   })
 
-  describe(`instance`, () => {
+  it('throws if there is no initial value provided', () => {
+    expect(() => new MemoizedSignal()).to.throw()
+  })
+
+  it('calls listener with most recently dispatched value', () => {
+    const spy = sinon.spy()
+    const args = [1, 'string', null, {}]
+    const signal = new MemoizedSignal(42)
+
+    signal.dispatch(...args)
+    signal.attach(spy)
+    sinon.assert.calledWithExactly(spy, ...args)
+  })
+
+  test(MemoizedSignal)
+})
+
+
+describe('Signal', () => test(Signal))
+
+function test (SignalConstructor) {
+  describe('instance', () => {
     let signal
+    let spies
     beforeEach(() => {
-      signal = new Signal()
+      signal = new SignalConstructor(40)
+      spies = {
+        one: sinon.spy(),
+        two: sinon.spy(),
+        three: sinon.spy(),
+        reset () {
+          this.one.reset()
+          this.two.reset()
+          this.three.reset()
+        },
+        expectCallCount (obj) {
+          for (let name in obj) {
+            expect(this[name]).to.have.callCount(obj[name])
+          }
+        }
+      }
     })
 
-    describe(`attach(listener)`, () => {
-      it(`returns a function`, () => {
+    describe('attach(listener)', () => {
+      it('returns a function', () => {
         expect(signal.attach(noop)).to.be.a('function')
       })
-      it(`throws an error if listener is not a function`, () => {
+
+      it('throws an error if listener is not a function', () => {
         ['foo', undefined, 42].forEach((value) => {
           expect(() => { signal.attach(value) }).to.throw()
         })
       })
+
+      it('detaches listener when returned function is invoked', () => {
+        const detach = signal.attach(spies.one)
+
+        spies.reset() // deal with memoization behaviour
+
+        signal.dispatch('holdthedoor')
+        sinon.assert.calledOnce(spies.one)
+        spies.reset()
+        detach()
+        signal.dispatch()
+        sinon.assert.notCalled(spies.one)
+      })
     })
 
-    describe(`dispatch()`, () => {
-      it(`returns nothing and does not fail`, () => {
-        expect(signal.dispatch()).to.equal(undefined)
+    describe('dispatch()', () => {
+      it('fires attached listeners in the same order they were attached', () => {
+        signal.attach(spies.one)
+        signal.attach(spies.two)
+        signal.attach(spies.three)
+        spies.reset() // since MemoizedSignal invokes cb on attach
+        signal.dispatch()
+
+        spies.expectCallCount({one: 1, two: 1, three: 1})
+
+        sinon.assert.callOrder(spies.one, spies.two, spies.three)
       })
 
-      describe(`with previously attached listeners`, () => {
-        let spies
-        beforeEach(() => {
-          spies = {
-            one: sinon.spy(),
-            two: sinon.spy(),
-            three: sinon.spy()
-          }
-        })
+      it('does not fire detached listeners', () => {
+        signal.attach(spies.one)()
+        signal.attach(spies.two)
+        spies.reset()
+        signal.dispatch()
 
-        function expectCallCount (obj) {
-          for (let name in obj) {
-            expect(spies[name]).to.have.callCount(obj[name])
-          }
-        }
+        spies.expectCallCount({one: 0, two: 1})
+      })
 
-        it(`fires attached listeners in the same order they were attached`, () => {
-          signal.attach(spies.one)
-          signal.attach(spies.two)
-          signal.attach(spies.three)
-          signal.dispatch()
+      it('fires reattached listeners', () => {
+        signal.attach(spies.one)()
+        spies.reset()
+        signal.dispatch()
 
-          expectCallCount({one: 1, two: 1, three: 1})
+        spies.expectCallCount({one: 0})
 
-          sinon.assert.callOrder(spies.one, spies.two, spies.three)
-        })
+        signal.attach(spies.one)
+        spies.reset()
+        signal.dispatch()
 
-        it(`does not fire detached listeners`, () => {
-          signal.attach(spies.one)()
-          signal.attach(spies.two)
-          signal.dispatch()
+        spies.expectCallCount({one: 1})
+      })
 
-          expectCallCount({one: 0, two: 1})
-        })
+      it('fires same listener attached twice two times', () => {
+        const detachSpyOneA = signal.attach(spies.one)
+        signal.attach(spies.one)
+        spies.reset() // reset call count increment caused by memoization behaviour
+        signal.dispatch()
+        spies.expectCallCount({one: 2})
 
-        it(`fires reattached listeners`, () => {
-          signal.attach(spies.one)()
-          signal.dispatch()
+        detachSpyOneA()
+        signal.dispatch()
 
-          expectCallCount({one: 0})
+        spies.expectCallCount({one: 3})
+      })
 
-          signal.attach(spies.one)
-          signal.dispatch()
+      it('passes given arguments to the listeners', () => {
+        const args = ['foo', 42, {}]
+        signal.attach(spies.one)
 
-          expectCallCount({one: 1})
-        })
+        signal.dispatch(...args)
+        sinon.assert.calledWithExactly(spies.one, ...args)
 
-        it(`fires same listener attached twice two times`, () => {
-          const detachSpyOneA = signal.attach(spies.one)
-          signal.attach(spies.one)
-          signal.dispatch()
-
-          expectCallCount({one: 2})
-
-          detachSpyOneA()
-          signal.dispatch()
-
-          expectCallCount({one: 3})
-        })
-
-        it(`passes given arguments to the listeners`, () => {
-          const args = ['foo', 42, {}]
-          signal.attach(spies.one)
-          signal.dispatch(...args)
-
-          expect(spies.one).to.have.been.calledWithExactly(...args)
-
-          signal.dispatch()
-
-          expect(spies.one).to.have.been.calledWithExactly()
-        })
+        signal.dispatch()
+        sinon.assert.calledWithExactly(spies.one)
       })
     })
   })
-})
+}

--- a/test/unit/space.spec.js
+++ b/test/unit/space.spec.js
@@ -3,6 +3,8 @@ const spaceMethods = [
   'getEntry',
   'getAsset',
 
+  'getPublishedEntries',
+  'getPublishedAssets',
   'getContentTypes',
   'getEntries',
   'getAssets',
@@ -34,8 +36,8 @@ const spaceMethods = [
 
 import createSpace from '../../lib/api/space'
 
-describe(`createSpace()`, () => {
-  describe(`returned "space" object`, () => {
+describe('createSpace()', () => {
+  describe('returned "space" object', () => {
     spaceMethods.forEach(describeSpaceMethod)
   })
 })
@@ -51,7 +53,7 @@ function describeSpaceMethod (methodName) {
   })
 
   describe(`.${methodName}()`, () => {
-    it(`is a function`, () => {
+    it('is a function', () => {
       expect(space[methodName]).to.be.a('function')
     })
     it(`invokes channel.call('callSpaceMethod', '${methodName}', args)`, () => {
@@ -61,7 +63,7 @@ function describeSpaceMethod (methodName) {
         .to.have.callCount(1).and
         .to.have.been.calledWithExactly('callSpaceMethod', methodName, args)
     })
-    it(`returns the promise returned by internal channel.call()`, () => {
+    it('returns the promise returned by internal channel.call()', () => {
       channelCallStub.withArgs('callSpaceMethod').returns('PROMISE')
       expect(space[methodName]()).to.equal('PROMISE')
     })


### PR DESCRIPTION
- [x] Expose `contentType`
- [x] Add private `setString` method
- [x] Change `setValue` to call `setString` or `setValue` based on type of widget
- [x] Update `signal` implementation to be in line with what's in UI repo
- [x] Expose `space.getPublishedEntries`
- [x] Expose `space.getPublishedAssets`
- [x] Fix broken `api.field.onValueChanged` behaviour (blocked till integration tests work so that we can test this breaking change properly)
- [x] Expose `field.removeValue`
- [x] Expose `field.onIsDisabledChanged`
- [x] Expose `field.setActive`
- [x] Expose `field.setInvalid`