### PR TITLE
fix: Handle 'undefined' call result

### DIFF
--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -43,15 +43,15 @@ export default class Channel {
         handlers.dispatch(...params)
       }
     } else {
-      const {id, result, error} = message
+      const {id} = message
       const responseHandler = this._responseHandlers[id]
       if (!responseHandler) {
         return
       }
-      if (result) {
-        responseHandler.resolve(result)
-      } else if (error) {
-        responseHandler.reject(error)
+      if ('result' in message) {
+        responseHandler.resolve(message.result)
+      } else if ('error' in message) {
+        responseHandler.reject(message.error)
       }
       delete this._responseHandlers[id]
     }

--- a/test/unit/channel.spec.js
+++ b/test/unit/channel.spec.js
@@ -94,6 +94,14 @@ describe(`Channel instance`, () => {
           expect(promise).to.eventually.equal(result)
             .and.notify(done)
         })
+
+        it(`resolves once the call got answered with an undefined result`, (done) => {
+          answerLastCallWith({result: undefined})
+
+          expect(promise).to.eventually.equal(undefined)
+            .and.notify(done)
+        })
+
         it(`gets rejected once the call got answered with an error`, (done) => {
           const error = 'What a mess!'
           answerLastCallWith({error})


### PR DESCRIPTION
Some method calls only want to indicate completion by returning a promise that resolves to `undefined`. We now handle that case.